### PR TITLE
Add web template

### DIFF
--- a/static/css/explore-wa.css
+++ b/static/css/explore-wa.css
@@ -1,0 +1,489 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800;900&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+
+:root {
+  --background: hsl(25, 18%, 8%);
+  --foreground: hsl(38, 35%, 88%);
+  --card: hsl(25, 20%, 12%);
+  --primary: hsl(42, 72%, 50%);
+  --secondary: hsl(30, 20%, 18%);
+  --muted-foreground: hsl(35, 15%, 55%);
+  --border: hsl(30, 18%, 22%);
+  --parchment-dark: hsl(35, 25%, 20%);
+  --brass: hsl(42, 72%, 50%);
+  --brass-glow: hsl(42, 80%, 60%);
+  --copper: hsl(25, 60%, 42%);
+  --font-heading: 'Cinzel', serif;
+  --font-body: 'Crimson Text', Georgia, serif;
+  --radius: 6px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  letter-spacing: 0.03em;
+  margin-top: 0;
+}
+
+p {
+  line-height: 1.65;
+}
+
+.site-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.container {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.glass-panel {
+  background: hsla(25, 20%, 12%, 0.7);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.nav-bar {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo-circle {
+  width: 36px;
+  height: 36px;
+  border: 2px solid var(--primary);
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: compass-spin 8s linear infinite;
+}
+
+.logo-text {
+  display: none;
+}
+
+.logo-title {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.logo-subtitle {
+  display: block;
+  font-size: 10px;
+  color: var(--muted-foreground);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.desktop-nav {
+  display: none;
+  align-items: center;
+  gap: 4px;
+}
+
+.desktop-nav a,
+.mobile-nav a {
+  font-family: var(--font-heading);
+  letter-spacing: 0.04em;
+  transition: all 0.2s ease;
+}
+
+.desktop-nav a {
+  padding: 10px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: var(--muted-foreground);
+}
+
+.desktop-nav a:hover {
+  color: var(--foreground);
+  background: var(--secondary);
+}
+
+.desktop-nav a.active,
+.mobile-nav a.active {
+  background: hsla(42, 72%, 50%, 0.15);
+  color: var(--primary);
+}
+
+.mobile-toggle {
+  display: inline-flex;
+  border: none;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.mobile-nav {
+  display: none;
+  border-top: 1px solid var(--border);
+  padding: 12px 24px 16px;
+}
+
+.mobile-nav.open {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mobile-nav a {
+  padding: 12px 14px;
+  border-radius: 4px;
+  color: var(--muted-foreground);
+  background: transparent;
+}
+
+.mobile-nav a:hover {
+  color: var(--foreground);
+  background: var(--secondary);
+}
+
+.main-content {
+  flex: 1;
+}
+
+.page-section {
+  padding-top: 48px;
+  padding-bottom: 48px;
+}
+
+.hero-block {
+  margin-bottom: 48px;
+}
+
+.page-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 12px 0 16px;
+}
+
+.hero-text {
+  max-width: 720px;
+  color: var(--muted-foreground);
+  font-size: 1.2rem;
+}
+
+.exhibit-label {
+  display: inline-block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-family: var(--font-heading);
+  color: var(--brass);
+}
+
+.brass-text {
+  background: linear-gradient(
+    135deg,
+    var(--brass) 0%,
+    var(--brass-glow) 40%,
+    var(--brass) 70%,
+    var(--copper) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.museum-card {
+  background:
+    linear-gradient(135deg, hsl(25, 20%, 12%) 0%, hsl(25, 22%, 14%) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow:
+    0 2px 8px hsla(0, 0%, 0%, 0.3),
+    inset 0 1px 0 hsla(30, 18%, 22%, 0.3);
+}
+
+.why-wa {
+  max-width: 860px;
+  margin-bottom: 48px;
+}
+
+.why-wa p + p {
+  margin-top: 16px;
+}
+
+.section-icon {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 16px;
+  font-size: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.section-icon.large {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 16px;
+  font-size: 32px;
+}
+
+.institution-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  margin-bottom: 48px;
+}
+
+.institution-grid h3 {
+  margin-bottom: 12px;
+  font-size: 1.15rem;
+}
+
+.institution-grid p {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.parchment-panel {
+  background: linear-gradient(
+    145deg,
+    hsl(35, 25%, 20%) 0%,
+    hsl(25, 18%, 16%) 50%,
+    hsl(35, 25%, 20%) 100%
+  );
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: inset 0 0 30px hsla(0, 0%, 0%, 0.2);
+}
+
+.uwa-panel {
+  padding: 32px;
+  margin-bottom: 48px;
+}
+
+.small-muted {
+  color: var(--muted-foreground);
+  font-size: 0.95rem;
+}
+
+.timeline-section {
+  margin-bottom: 48px;
+}
+
+.timeline-label {
+  margin-bottom: 24px;
+}
+
+.topics-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.topic-link-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  transition: all 0.25s ease;
+}
+
+.topic-link-card:hover {
+  border-color: hsla(42, 72%, 50%, 0.4);
+  transform: translateY(-2px);
+}
+
+.topic-pin {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: hsla(42, 72%, 50%, 0.1);
+  border: 1px solid hsla(42, 72%, 50%, 0.3);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.topic-content {
+  flex: 1;
+}
+
+.topic-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.topic-title {
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.topic-link-card:hover .topic-title {
+  color: var(--primary);
+}
+
+.topic-year {
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+}
+
+.topic-desc {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.98rem;
+}
+
+.topic-arrow {
+  opacity: 0;
+  color: var(--primary);
+  margin-top: 6px;
+  transition: opacity 0.2s ease;
+}
+
+.topic-link-card:hover .topic-arrow {
+  opacity: 1;
+}
+
+.coming-soon {
+  border-style: dashed;
+  text-align: center;
+  padding-top: 48px;
+  padding-bottom: 48px;
+}
+
+.coming-soon h3 {
+  margin: 8px 0 12px;
+}
+
+.coming-soon p {
+  max-width: 520px;
+  margin: 0 auto;
+  color: var(--muted-foreground);
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 32px 0;
+  margin-top: 64px;
+}
+
+.footer-inner {
+  text-align: center;
+}
+
+.footer-text {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin: 8px 0 0;
+}
+
+.fade-in {
+  animation: fade-in 0.6s ease-out forwards;
+}
+
+.hidden {
+  display: none;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes compass-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--background);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: hsla(42, 72%, 50%, 0.5);
+}
+
+@media (min-width: 640px) {
+  .logo-text {
+    display: block;
+  }
+}
+
+@media (min-width: 1024px) {
+  .desktop-nav {
+    display: flex;
+  }
+
+  .mobile-toggle,
+  .mobile-nav {
+    display: none !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .institution-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/static/css/topic-detail.css
+++ b/static/css/topic-detail.css
@@ -1,0 +1,196 @@
+@import url("./explore-wa.css");
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted-foreground);
+  font-size: 14px;
+  margin-bottom: 32px;
+  font-family: var(--font-heading);
+}
+
+.breadcrumb a {
+  color: var(--muted-foreground);
+}
+
+.breadcrumb a:hover {
+  color: var(--primary);
+}
+
+.header-block {
+  margin-bottom: 48px;
+}
+
+.header-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.meta-muted {
+  font-size: 14px;
+  color: var(--muted-foreground);
+  font-family: var(--font-heading);
+}
+
+.year-text {
+  font-size: 1.1rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-heading);
+  margin-bottom: 24px;
+}
+
+.archival-divider {
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(to right, transparent, var(--primary), transparent);
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+}
+
+.main-column,
+.sidebar-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.block-label {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.intro-text {
+  color: var(--foreground);
+  line-height: 1.8;
+  font-size: 1.15rem;
+}
+
+.summary-card {
+  border-left: 4px solid var(--primary);
+}
+
+.summary-text,
+.section-text,
+.reference-meta,
+.reference-notes,
+.media-caption {
+  color: var(--muted-foreground);
+  line-height: 1.7;
+}
+
+.section-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.section-emoji {
+  font-size: 18px;
+}
+
+.sidebar-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.media-item {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.media-image {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+}
+
+.media-caption-box {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.media-title {
+  margin: 0 0 6px;
+  font-family: var(--font-heading);
+  font-size: 13px;
+}
+
+.reference-item {
+  padding: 12px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.reference-link {
+  color: var(--primary);
+  font-family: var(--font-heading);
+  font-size: 14px;
+}
+
+.reference-link:hover {
+  text-decoration: underline;
+}
+
+.related-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 4px;
+  transition: 0.2s ease;
+}
+
+.related-link:hover {
+  background: var(--secondary);
+}
+
+.related-id {
+  color: var(--primary);
+  font-family: var(--font-heading);
+}
+
+.bottom-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.nav-card {
+  display: inline-block;
+  min-width: 220px;
+}
+
+.nav-card-right {
+  text-align: right;
+}
+
+.nav-direction {
+  font-size: 12px;
+  color: var(--muted-foreground);
+  margin-bottom: 6px;
+}
+
+.nav-title {
+  font-size: 14px;
+  font-family: var(--font-heading);
+  color: var(--foreground);
+}
+
+@media (min-width: 1024px) {
+  .content-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}

--- a/static/js/explore-wa.js
+++ b/static/js/explore-wa.js
@@ -1,0 +1,57 @@
+const navItems = [
+  { path: "home.html", label: "Home" },
+  { path: "timeline.html", label: "Timeline" },
+  { path: "explore_WA.html", label: "Explore WA" },
+  { path: "guided_tour.html", label: "Guided Tour" },
+  { path: "search.html", label: "Search" }
+];
+
+function renderNav() {
+  const desktopNav = document.getElementById("desktopNav");
+  const mobileNav = document.getElementById("mobileNav");
+  const currentPage = "explore_WA.html";
+
+  const html = navItems.map(item => {
+    const activeClass = item.path === currentPage ? "active" : "";
+    return `<a href="${item.path}" class="${activeClass}">${item.label}</a>`;
+  }).join("");
+
+  desktopNav.innerHTML = html;
+  mobileNav.innerHTML = html;
+}
+
+function renderTopics() {
+  const topicsList = document.getElementById("topicsList");
+
+  topicsList.innerHTML = topics.map(topic => {
+    return `
+      <a href="topic_detail.html?slug=${topic.slug}" class="museum-card topic-link-card">
+        <div class="topic-pin">📍</div>
+        <div class="topic-content">
+          <div class="topic-header">
+            <span class="topic-title">${topic.title}</span>
+            <span class="topic-year">${topic.yearRange}</span>
+          </div>
+          <p class="topic-desc">${topic.waContext}</p>
+        </div>
+        <div class="topic-arrow">→</div>
+      </a>
+    `;
+  }).join("");
+}
+
+function setupMobileMenu() {
+  const mobileToggle = document.getElementById("mobileToggle");
+  const mobileNav = document.getElementById("mobileNav");
+
+  if (!mobileToggle || !mobileNav) return;
+
+  mobileToggle.addEventListener("click", () => {
+    mobileNav.classList.toggle("open");
+    mobileToggle.textContent = mobileNav.classList.contains("open") ? "✕" : "☰";
+  });
+}
+
+renderNav();
+renderTopics();
+setupMobileMenu();

--- a/static/js/topic-detail.js
+++ b/static/js/topic-detail.js
@@ -1,0 +1,180 @@
+const navItems = [
+  { path: "home.html", label: "Home" },
+  { path: "timeline.html", label: "Timeline" },
+  { path: "explore_WA.html", label: "Explore WA" },
+  { path: "guided_tour.html", label: "Guided Tour" },
+  { path: "search.html", label: "Search" }
+];
+
+
+function getQueryParam(name) {
+  const url = new URL(window.location.href);
+  return url.searchParams.get(name);
+}
+
+function renderNav() {
+  const desktopNav = document.getElementById("desktopNav");
+  const mobileNav = document.getElementById("mobileNav");
+
+  const html = navItems.map(item => {
+    const activeClass = item.label === "Explore WA" ? "active" : "";
+    return `<a href="${item.path}" class="${activeClass}">${item.label}</a>`;
+  }).join("");
+
+  desktopNav.innerHTML = html;
+  mobileNav.innerHTML = html;
+}
+
+function renderTopicPage() {
+  const slug = getQueryParam("slug");
+  const topic = getTopicBySlug(slug);
+
+  if (!topic) {
+    document.querySelector(".page-section").innerHTML = `
+      <div style="text-align:center; padding:80px 20px;">
+        <h1 class="page-title brass-text">Exhibit Not Found</h1>
+        <p style="margin-top:16px;">
+          <a href="explore_WA.html" style="color:#d4a017;">Return to Explore WA</a>
+        </p>
+      </div>
+    `;
+    return;
+  }
+
+  const { prev, next } = getAdjacentTopics(topic.id);
+
+  document.getElementById("breadcrumb").innerHTML = `
+    <a href="home.html">Timeline</a>
+    <span>›</span>
+    <span>${topic.title}</span>
+  `;
+
+  document.getElementById("topicHeader").innerHTML = `
+    <div class="header-block">
+      <div class="header-meta">
+        <span class="exhibit-label">${topic.category}</span>
+        <span class="meta-muted">Exhibit #${topic.id}</span>
+      </div>
+      <h1 class="page-title brass-text">${topic.title}</h1>
+      <p class="year-text">${topic.yearRange}</p>
+      <div class="archival-divider"></div>
+    </div>
+  `;
+
+  document.getElementById("introCard").innerHTML = `
+    <div class="museum-card">
+      <span class="exhibit-label block-label">Introduction</span>
+      <p class="intro-text">${topic.introText}</p>
+    </div>
+  `;
+
+  document.getElementById("summaryCard").innerHTML = `
+    <div class="museum-card summary-card">
+      <span class="exhibit-label block-label">Key Takeaways</span>
+      <p class="summary-text">${topic.shortSummary}</p>
+    </div>
+  `;
+
+  const sections = [
+    { title: "How It Works", content: topic.howItWorks, icon: "⚙️" },
+    { title: "Simple Example", content: topic.simpleExample, icon: "💡" },
+    { title: "Where Most Effective", content: topic.effectiveUse, icon: "⚡" },
+    { title: "Real-World Examples", content: topic.realWorldExamples, icon: "👁️" },
+    { title: "Advantages", content: topic.advantages, icon: "👍" },
+    { title: "Limitations", content: topic.limitations, icon: "⛔" },
+    { title: "Possible Misuse", content: topic.misuse, icon: "⚠️" },
+    { title: "Ethical Concerns", content: topic.ethics, icon: "🛡️" },
+    { title: "WA Connection", content: topic.waContext, icon: "📍" }
+  ];
+
+  document.getElementById("sectionsContainer").innerHTML = sections.map(section => `
+    <div class="museum-card section-card">
+      <div class="section-title-row">
+        <span class="section-emoji">${section.icon}</span>
+        <span class="exhibit-label">${section.title}</span>
+      </div>
+      <p class="section-text">${section.content}</p>
+    </div>
+  `).join("");
+
+  document.getElementById("mediaCard").innerHTML = `
+    <div class="museum-card">
+      <span class="exhibit-label block-label">Media Gallery</span>
+      <div class="sidebar-stack">
+        ${topic.media.map(item => `
+          <div class="media-item">
+            <img src="${item.url}" alt="${item.caption}" class="media-image" />
+            <div class="media-caption-box">
+              <p class="media-title">${item.title}</p>
+              <p class="media-caption">${item.caption}</p>
+            </div>
+          </div>
+        `).join("")}
+      </div>
+    </div>
+  `;
+
+  document.getElementById("referencesCard").innerHTML = `
+    <div class="museum-card">
+      <span class="exhibit-label block-label">References & Sources</span>
+      <div class="sidebar-stack">
+        ${topic.references.map(ref => `
+          <div class="reference-item">
+            <a href="${ref.url}" target="_blank" rel="noopener noreferrer" class="reference-link">${ref.title}</a>
+            <p class="reference-meta">${ref.sourceType} · ${ref.accessedDate}</p>
+            <p class="reference-notes">${ref.notes}</p>
+          </div>
+        `).join("")}
+      </div>
+    </div>
+  `;
+
+  document.getElementById("relatedCard").innerHTML = `
+    <div class="museum-card">
+      <span class="exhibit-label block-label">Related Exhibits</span>
+      <div class="sidebar-stack">
+        ${topics.filter(t => t.id !== topic.id).slice(0, 3).map(t => `
+          <a href="topic_detail.html?slug=${t.slug}" class="related-link">
+            <span class="related-id">#${t.id}</span>
+            <span>${t.title}</span>
+          </a>
+        `).join("")}
+      </div>
+    </div>
+  `;
+
+  document.getElementById("bottomNav").innerHTML = `
+    <div>
+      ${prev ? `
+        <a href="topic_detail.html?slug=${prev.slug}" class="museum-card nav-card">
+          <div class="nav-direction">Previous</div>
+          <div class="nav-title">← ${prev.title}</div>
+        </a>
+      ` : ""}
+    </div>
+    <div>
+      ${next ? `
+        <a href="topic_detail.html?slug=${next.slug}" class="museum-card nav-card nav-card-right">
+          <div class="nav-direction">Next Discovery</div>
+          <div class="nav-title">${next.title} →</div>
+        </a>
+      ` : ""}
+    </div>
+  `;
+}
+
+function setupMobileMenu() {
+  const mobileToggle = document.getElementById("mobileToggle");
+  const mobileNav = document.getElementById("mobileNav");
+
+  if (!mobileToggle || !mobileNav) return;
+
+  mobileToggle.addEventListener("click", () => {
+    mobileNav.classList.toggle("open");
+    mobileToggle.textContent = mobileNav.classList.contains("open") ? "✕" : "☰";
+  });
+}
+
+renderNav();
+renderTopicPage();
+setupMobileMenu();

--- a/static/js/topic_data.js
+++ b/static/js/topic_data.js
@@ -1,0 +1,480 @@
+const topics = [
+  {
+    id: 1,
+    slug: "turing-thoughts-on-ai",
+    title: "Alan Turing's Thoughts on AI",
+    yearRange: "c. 1950",
+    category: "Foundations",
+    introText: "Alan Turing's ideas laid the intellectual groundwork for artificial intelligence. His questions about whether machines can think became central to later AI research.",
+    shortSummary: "Turing provided the conceptual foundations for machine intelligence.",
+    howItWorks: "This topic focuses on theoretical ideas about computation, intelligence, and symbolic reasoning rather than a single application system.",
+    simpleExample: "A machine following formal logical steps to solve a problem reflects Turing's vision of computation.",
+    effectiveUse: "Most effective in foundational teaching, philosophy of AI, and computational theory.",
+    realWorldExamples: "University teaching, theoretical computer science, and early AI research.",
+    advantages: "Provides a strong conceptual basis for later technologies.",
+    limitations: "Highly theoretical and not a direct end-user system.",
+    misuse: "Can be oversimplified when discussing modern AI.",
+    ethics: "Raises questions about intelligence, autonomy, and human-machine comparison.",
+    waContext: "The University of Western Australia's Computer Science department has long incorporated Turing's theories into its foundational curriculum.",
+    media: [
+      {
+        id: 1,
+        type: "image",
+        url: "https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1200&q=80",
+        title: "Computing Foundations",
+        caption: "Theoretical work shaped the future of AI."
+      }
+    ],
+    references: [
+      {
+        id: 1,
+        title: "Foundational AI History",
+        url: "https://en.wikipedia.org/wiki/Alan_Turing",
+        sourceType: "Background Source",
+        accessedDate: "Accessed 2026",
+        notes: "General background on Turing and computing history."
+      }
+    ]
+  },
+  {
+    id: 2,
+    slug: "learning-machines",
+    title: "Learning Machines",
+    yearRange: "c. 1960",
+    category: "Machine Learning",
+    introText: "Learning machines marked a shift from explicit programming toward systems that could improve through data and experience.",
+    shortSummary: "Machines began to learn patterns rather than rely only on fixed hand-written rules.",
+    howItWorks: "These systems use training data to identify patterns and improve decision-making over time.",
+    simpleExample: "A model trained on past weather data predicts tomorrow's temperature range.",
+    effectiveUse: "Useful when large amounts of data are available and patterns can be learned statistically.",
+    realWorldExamples: "Prediction systems, classification, industrial monitoring, and analytics.",
+    advantages: "Can adapt better than rigid rule-based systems in changing environments.",
+    limitations: "Needs data quality, computational power, and careful evaluation.",
+    misuse: "Can produce misleading results when trained on biased or poor-quality data.",
+    ethics: "Raises concerns about fairness, transparency, and accountability.",
+    waContext: "WA universities and research groups have contributed to machine learning education and research.",
+    media: [
+      {
+        id: 1,
+        type: "image",
+        url: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?auto=format&fit=crop&w=1200&q=80",
+        title: "Learning from Data",
+        caption: "Data-driven approaches transformed AI development."
+      }
+    ],
+    references: [
+      {
+        id: 1,
+        title: "Machine Learning Overview",
+        url: "https://en.wikipedia.org/wiki/Machine_learning",
+        sourceType: "Background Source",
+        accessedDate: "Accessed 2026",
+        notes: "General introductory material."
+      }
+    ]
+  },
+  {
+    id: 3,
+    slug: "game-playing-ai",
+    title: "Game Playing AI",
+    yearRange: "c. 1970",
+    category: "Strategic Systems",
+    introText: "Game-playing AI demonstrated that machines could make strategic decisions in structured environments.",
+    shortSummary: "Game AI made abstract reasoning and search visible and measurable.",
+    howItWorks: "These systems explore possible future moves and evaluate game states to choose effective strategies.",
+    simpleExample: "A chess engine examines several possible moves and chooses the one with the highest evaluation.",
+    effectiveUse: "Best in structured problems with clear rules and goals.",
+    realWorldExamples: "Chess engines, board games, and teaching search algorithms.",
+    advantages: "Excellent for demonstrating planning and search methods.",
+    limitations: "Performs best in closed systems with well-defined rules.",
+    misuse: "People may assume success in games always transfers to messy real-world tasks.",
+    ethics: "Limited direct ethical risk, but influences public perception of AI capability.",
+    waContext: "WA computing programs have used game-playing systems as teaching tools for search, heuristics, and decision-making.",
+    media: [
+      {
+        id: 1,
+        type: "image",
+        url: "https://images.unsplash.com/photo-1528819622765-d6bcf132f793?auto=format&fit=crop&w=1200&q=80",
+        title: "Strategic Search",
+        caption: "Game environments provided clear testbeds for AI reasoning."
+      }
+    ],
+    references: [
+      {
+        id: 1,
+        title: "Game AI Background",
+        url: "https://en.wikipedia.org/wiki/Game_artificial_intelligence",
+        sourceType: "Background Source",
+        accessedDate: "Accessed 2026",
+        notes: "General overview source."
+      }
+    ]
+  },
+  {
+    id: 4,
+    slug: "expert-systems",
+    title: "Expert Systems",
+    yearRange: "c. 1980",
+    category: "Knowledge Engineering",
+    introText: "In the 1980s, expert systems became the first commercially successful form of AI. These programs encoded the decision-making knowledge of human experts into software using rules, facts, and inference engines. Systems like MYCIN, DENDRAL, and R1/XCON demonstrated that AI could provide practical value in professional domains.",
+    shortSummary: "Expert systems captured human specialist knowledge in rule-based software, enabling computers to make decisions in medicine, finance, and engineering by following chains of if-then logic.",
+    howItWorks: "An expert system consists of three components: a knowledge base, an inference engine, and a user interface. The knowledge base stores rules and facts collected from experts. The inference engine applies these rules step by step to reach a conclusion.",
+    simpleExample: "If a patient has fever and cough, and recently travelled, the system may suggest considering a tropical disease. This imitates how a specialist reasons from symptoms to diagnosis.",
+    effectiveUse: "Most effective in narrow domains where knowledge can be clearly expressed as rules, such as diagnosis, equipment configuration, tax advice, and troubleshooting.",
+    realWorldExamples: "MYCIN for medical diagnosis, DENDRAL for chemistry, and XCON for configuring computer systems at Digital Equipment Corporation.",
+    advantages: "They preserve expert knowledge, provide consistent decisions, and work well in specialised areas where human expertise is expensive or scarce.",
+    limitations: "They are brittle, hard to maintain, and struggle with uncertainty, ambiguity, and rapidly changing domains. Building the knowledge base is also labour-intensive.",
+    misuse: "They can be misused when applied outside their narrow domain, or when users trust them too much without human verification.",
+    ethics: "Important concerns include accountability for wrong recommendations, transparency of rules, and over-reliance on automated advice in high-stakes domains.",
+    waContext: "Expert systems influenced decision support work in WA across mining, agriculture, and environmental management, where codified knowledge could be embedded into software tools.",
+    media: [
+      {
+        id: 1,
+        type: "image",
+        url: "https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=1200&q=80",
+        title: "Knowledge Engineering Process",
+        caption: "The process of capturing expert knowledge into rule-based systems."
+      },
+      {
+        id: 2,
+        type: "image",
+        url: "https://images.unsplash.com/photo-1576091160550-2173dba999ef?auto=format&fit=crop&w=1200&q=80",
+        title: "Medical Expert Systems",
+        caption: "Expert systems found early success in medical diagnosis."
+      }
+    ],
+    references: [
+      {
+        id: 1,
+        title: "Rule-based Expert Systems",
+        url: "https://en.wikipedia.org/wiki/Expert_system",
+        sourceType: "Background Source",
+        accessedDate: "Accessed 2026",
+        notes: "General overview of expert systems."
+      }
+    ]
+  },
+    {
+    id: 5,
+    slug: "artificial-neural-nets",
+    title: "Artificial Neural Networks",
+    yearRange: "1980–2000",
+    category: "Neural Computing",
+    introText: "Artificial neural networks (ANNs) experienced a renaissance in the 1980s with the development of backpropagation — an efficient algorithm for training multi-layer networks. Unlike expert systems, neural networks could learn patterns directly from data without explicit rules, making them suited for tasks like image recognition, speech processing, and financial prediction.",
+    shortSummary: "Inspired by the human brain, artificial neural networks learned complex patterns through layers of interconnected nodes, overcoming the limitations of earlier approaches and laying the foundation for deep learning.",
+    howItWorks: "A neural network consists of layers of artificial neurons (nodes). Each connection between nodes has a weight. Data enters the input layer, passes through hidden layers where weighted sums are computed and activation functions applied, and produces output. During training, backpropagation calculates how much each weight contributed to errors, then adjusts weights to reduce future errors. Through thousands of iterations, the network learns to map inputs to correct outputs.",
+    simpleExample: "Imagine a team passing a message through a chain. Each person slightly modifies the message based on what they think is important. After checking if the final message is correct, feedback goes back through the chain — each person adjusts how they modify messages. After many rounds, the team reliably produces correct messages.",
+    effectiveUse: "Pattern recognition in images, speech, and text. Regression and classification tasks. Applications where the underlying rules are too complex to express explicitly but sufficient training data exists.",
+    realWorldExamples: "Handwriting recognition (used in postal sorting), early speech recognition systems, financial market prediction models, and medical image analysis. LeCun's convolutional neural networks for digit recognition at Bell Labs became a landmark achievement.",
+    advantages: "Could learn complex, non-linear patterns that rule-based systems couldn't capture. Generalised to new, unseen data. Required no manual knowledge engineering — learning was automatic. Scaled with more data and computation.",
+    limitations: "Required large amounts of training data. Training was computationally expensive with 1980s-2000s hardware. Networks were 'black boxes' — difficult to explain why a particular decision was made. Prone to overfitting on small datasets.",
+    misuse: "Black-box nature allowed deployment in high-stakes decisions (credit scoring, criminal justice) without explainability. Biased training data produced biased models that could discriminate against protected groups without anyone understanding why.",
+    ethics: "The opacity of neural network decisions raises accountability concerns. When a neural network denies someone a loan or flags them as suspicious, the lack of explainable reasoning conflicts with requirements for fair, transparent decision-making.",
+    waContext: "WA universities, particularly UWA and Curtin, established neural computing research groups in the 1990s. Applications in mineral exploration, environmental monitoring, and agricultural prediction were developed by WA researchers, applying neural networks to the state's dominant industries.",
+    media: [
+      {
+        id: 9,
+        type: "image",
+        title: "Neural Network Architecture",
+        url: "https://images.unsplash.com/photo-1620712943543-bcc4688e7485?w=600",
+        caption: "Visualisation of neural network layers and connections"
+      },
+      {
+        id: 10,
+        type: "image",
+        title: "Brain-Inspired Computing",
+        url: "https://images.unsplash.com/photo-1559757175-5700dde675bc?w=600",
+        caption: "Neural networks drew inspiration from biological neural structures"
+      }
+    ],
+    references: [
+      {
+        id: 9,
+        title: "Learning Representations by Back-propagating Errors",
+        url: "https://www.nature.com/articles/323533a0",
+        sourceType: "Research Paper",
+        accessedDate: "2024-02-15",
+        notes: "Rumelhart, Hinton & Williams' seminal 1986 paper"
+      },
+      {
+        id: 10,
+        title: "Neural Networks and Deep Learning",
+        url: "http://neuralnetworksanddeeplearning.com/",
+        sourceType: "Online Book",
+        accessedDate: "2024-02-15",
+        notes: "Michael Nielsen's accessible introduction"
+      }
+    ]
+  },
+  {
+    id: 6,
+    slug: "internet-driven-ai-ibm-watson",
+    title: "Internet-Driven AI / IBM Watson",
+    yearRange: "c. 2011",
+    category: "Knowledge Retrieval",
+    introText: "In 2011, IBM Watson competed on Jeopardy! against champions Ken Jennings and Brad Rutter — and won. Watson represented a new paradigm: AI that could process enormous volumes of unstructured text, understand natural language questions, and generate accurate answers in real time. The internet age had created vast repositories of human knowledge, and Watson showed that AI could harness this information at superhuman speed.",
+    shortSummary: "IBM Watson demonstrated that AI could process vast amounts of internet-scale data to answer natural language questions, defeating Jeopardy! champions and showcasing a new era of knowledge-driven AI.",
+    howItWorks: "Watson used a massively parallel architecture called DeepQA. When given a question, it generated hundreds of candidate answers by searching through millions of documents. It then used over 100 different scoring algorithms to evaluate each candidate — checking evidence from multiple sources, analysing linguistic patterns, and assessing confidence. The candidate with the highest aggregate confidence score was selected as the answer. All of this happened in under 3 seconds.",
+    simpleExample: "Imagine asking a question and having a thousand researchers simultaneously search through every encyclopedia, textbook, and article ever written, each providing their best answer with a confidence level. Watson essentially does this digitally, then picks the answer that the most 'researchers' agree on.",
+    effectiveUse: "Question answering, information retrieval, medical literature analysis, legal document review, customer service automation, and any domain requiring synthesis of large text corpora.",
+    realWorldExamples: "Watson for Oncology assisted doctors by analysing medical literature for treatment recommendations. Watson Discovery helped legal firms search case law. Watson Assistant powers enterprise customer service chatbots. The Jeopardy! victory remains its most famous demonstration.",
+    advantages: "Could process and synthesise information from millions of documents. Provided evidence-based answers with confidence scores. Worked with unstructured natural language rather than requiring structured queries. Demonstrated practical AI value to a mass audience.",
+    limitations: "Required enormous computational resources. Watson for Oncology faced criticism for providing unsafe treatment recommendations in some cases. The system struggled with domains where evidence was ambiguous or rapidly changing. Commercialisation proved more difficult than the dramatic demo suggested.",
+    misuse: "IBM's marketing overpromised Watson's capabilities, leading to failed implementations in healthcare and other domains. The gap between demonstration performance and real-world deployment highlighted risks of AI hype.",
+    ethics: "Raised concerns about AI in medical decision-making — who is accountable when Watson recommends an incorrect treatment? Also highlighted the danger of treating AI as infallible authority because of impressive demonstrations.",
+    waContext: "WA's healthcare and resources sectors explored Watson-style AI for document analysis and decision support. Perth hospitals investigated AI-assisted diagnosis tools influenced by Watson's approach. WA's tech sector began positioning itself in the enterprise AI space following Watson's high-profile success.",
+    media: [
+      {
+        id: 11,
+        type: "image",
+        title: "Watson on Jeopardy!",
+        url: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?w=600",
+        caption: "AI competing against human champions in knowledge retrieval"
+      },
+      {
+        id: 12,
+        type: "image",
+        title: "Big Data Processing",
+        url: "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=600",
+        caption: "The massive data processing infrastructure behind Watson"
+      }
+    ],
+    references: [
+      {
+        id: 11,
+        title: "Building Watson: An Overview of the DeepQA Project",
+        url: "https://www.aaai.org/ojs/index.php/aimagazine/article/view/2303",
+        sourceType: "Research Paper",
+        accessedDate: "2024-02-20",
+        notes: "IBM Research's technical overview of Watson's architecture"
+      },
+      {
+        id: 12,
+        title: "Watson: Beyond Jeopardy!",
+        url: "https://www.ibm.com/watson",
+        sourceType: "Web Archive",
+        accessedDate: "2024-02-20",
+        notes: "IBM's Watson platform documentation"
+      }
+    ]
+  },
+  {
+    id: 7,
+    slug: "evolutionary-computing-genetic-algorithms",
+    title: "Evolutionary Computing & Genetic Algorithms",
+    yearRange: "c. 2010",
+    category: "Bio-Inspired AI",
+    introText: "Evolutionary computing draws direct inspiration from biological evolution. Genetic algorithms (GAs) create populations of candidate solutions, evaluate their fitness, and breed the best performers through crossover and mutation. Over many generations, solutions evolve to optimise complex problems that traditional methods struggle with. By the 2010s, evolutionary approaches were applied to engineering design, logistics, scheduling, and even creative applications.",
+    shortSummary: "Genetic algorithms applied Darwin's principles of natural selection to computing — evolving solutions to complex problems through mutation, crossover, and survival of the fittest.",
+    howItWorks: "A genetic algorithm starts with a random population of solutions, each encoded as a 'chromosome' (string of parameters). A fitness function evaluates each solution's quality. The best performers are selected as 'parents' and combined through crossover (mixing parts of two solutions) and mutation (randomly changing elements). This produces a new generation. The process repeats for hundreds or thousands of generations, with solutions progressively improving through simulated natural selection.",
+    simpleExample: "Imagine designing the perfect paper airplane. You create 100 random designs, throw them all, and measure distance. Take the 10 best, combine features from pairs of top performers (fold style from one, wing shape from another), add small random changes, and create 100 new designs. Repeat 1000 times. The final designs will fly remarkably well.",
+    effectiveUse: "Optimisation problems with large search spaces where exact solutions are impractical: engineering design, scheduling, routing, parameter tuning, circuit design, and creative applications like evolving art or music.",
+    realWorldExamples: "NASA used genetic algorithms to design antenna shapes for spacecraft. Automotive companies evolved crash-resistant vehicle structures. Logistics companies optimised delivery routes. Financial firms evolved trading strategies. Even artistic applications emerged — evolving visual art and music compositions.",
+    advantages: "Can find good solutions to problems too complex for analytical approaches. Don't require gradient information or continuous functions. Can explore multiple solution areas simultaneously. Naturally avoid getting stuck in local optima. Produce creative, unexpected solutions that human designers might not consider.",
+    limitations: "No guarantee of finding the global optimum. Computationally expensive for large populations over many generations. Fitness function design is critical and can bias results. Parameter tuning (population size, mutation rate, crossover method) requires expertise.",
+    misuse: "Genetic algorithms have been used to evolve adversarial attacks on other AI systems. Automated optimisation without constraints can produce technically efficient but ethically problematic solutions.",
+    ethics: "When evolutionary algorithms optimise for narrow fitness criteria, they can discover solutions that exploit loopholes or cause unintended consequences. This highlights the importance of defining optimisation goals carefully and considering broader impacts.",
+    waContext: "WA researchers have applied genetic algorithms extensively in mining optimisation — from pit design to ore processing schedules. UWA and Curtin have active research groups in evolutionary computing. The WA resources sector's complex logistics and scheduling problems make it a natural application domain for evolutionary approaches.",
+    media: [
+      {
+        id: 13,
+        type: "image",
+        title: "Evolutionary Process Diagram",
+        url: "https://images.unsplash.com/photo-1530026405186-ed1f139313f8?w=600",
+        caption: "The cycle of selection, crossover, and mutation in genetic algorithms"
+      },
+      {
+        id: 14,
+        type: "image",
+        title: "Optimisation in Nature",
+        url: "https://images.unsplash.com/photo-1500462918059-b1a0cb512f1d?w=600",
+        caption: "Nature's evolutionary processes inspire computational optimisation"
+      }
+    ],
+    references: [
+      {
+        id: 13,
+        title: "Genetic Algorithms in Search, Optimization and Machine Learning",
+        url: "https://dl.acm.org/doi/book/10.5555/534133",
+        sourceType: "Book",
+        accessedDate: "2024-03-01",
+        notes: "Goldberg's foundational textbook on genetic algorithms"
+      },
+      {
+        id: 14,
+        title: "Evolutionary Computation: Toward a New Philosophy of Machine Intelligence",
+        url: "https://ieeexplore.ieee.org/",
+        sourceType: "Book",
+        accessedDate: "2024-03-01",
+        notes: "Fogel's comprehensive overview of the field"
+      }
+    ]
+  },
+  {
+    id: 8,
+    slug: "deep-fakes",
+    title: "Deep Fakes",
+    yearRange: "c. 2015",
+    category: "Generative AI & Deception",
+    introText: "Deep fakes emerged around 2015 as advances in deep learning — particularly Generative Adversarial Networks (GANs) — made it possible to create highly realistic fake media. A 'deep fake' uses neural networks to swap faces in video, clone voices, or generate entirely synthetic images of people who don't exist. The technology rapidly improved from obvious fakes to nearly undetectable fabrications, creating urgent challenges for journalism, democracy, and personal security.",
+    shortSummary: "Deep fake technology uses neural networks to create convincing fake images, audio, and video, raising unprecedented challenges for trust, media integrity, and digital security.",
+    howItWorks: "Most deep fakes use Generative Adversarial Networks (GANs), which pit two neural networks against each other: a Generator creates fake content, and a Discriminator tries to identify fakes. They train together in competition — the Generator improves at creating realistic fakes while the Discriminator improves at detecting them. Through thousands of training rounds, the Generator produces increasingly convincing content. Face-swapping specifically uses autoencoders that learn to reconstruct faces, then swap the encoding of one face onto another's structure.",
+    simpleExample: "Imagine two art students: one creates forgeries of famous paintings, the other tries to spot them. They keep competing — the forger gets better at copying, the detective gets better at spotting fakes. Eventually, the forgeries become nearly indistinguishable from originals.",
+    effectiveUse: "Film and entertainment (de-aging actors, visual effects), accessibility (translating sign language, dubbing content), art and creative expression, privacy protection (anonymising faces in footage), and medical imaging augmentation for training purposes.",
+    realWorldExamples: "Face-swapping in Hollywood films (de-aging Robert De Niro in The Irishman). Voice cloning for accessibility applications. Synthetic media for training datasets. Unfortunately also used to create non-consensual intimate imagery and political disinformation.",
+    advantages: "Enables powerful creative and entertainment applications. Can protect privacy by generating synthetic stand-ins. Aids in medical research through synthetic data generation. Demonstrates remarkable advances in generative AI capability.",
+    limitations: "Current detection tools are in an arms race with generation tools. Subtle artifacts (blinking patterns, skin texture, lighting inconsistencies) can reveal fakes but detection is not reliable. Once shared, fake content spreads faster than debunking.",
+    misuse: "Non-consensual intimate imagery (the most common misuse), political disinformation, financial fraud through voice cloning, identity theft, fabricated evidence, and erosion of trust in all digital media.",
+    ethics: "Deep fakes represent one of the most urgent ethical challenges in AI. They threaten informed consent, democratic processes, journalism integrity, and personal safety. The technology forces society to reconsider what constitutes 'evidence' and 'truth' in the digital age.",
+    waContext: "WA law enforcement and cybersecurity researchers have been active in deep fake detection research. Edith Cowan University's Security Research Institute has studied digital forensics approaches to identifying manipulated media. WA's growing cybersecurity sector positions the state as a contributor to the global response to synthetic media threats.",
+    media: [
+      {
+        id: 15,
+        type: "image",
+        title: "Synthetic Media Generation",
+        url: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?w=600",
+        caption: "The technology behind generating synthetic media content"
+      },
+      {
+        id: 16,
+        type: "image",
+        title: "Digital Forensics",
+        url: "https://images.unsplash.com/photo-1563986768609-322da13575f2?w=600",
+        caption: "Digital forensics tools used to detect manipulated media"
+      }
+    ],
+    references: [
+      {
+        id: 15,
+        title: "Generative Adversarial Networks",
+        url: "https://arxiv.org/abs/1406.2661",
+        sourceType: "Research Paper",
+        accessedDate: "2024-03-10",
+        notes: "Goodfellow et al.'s original GAN paper"
+      },
+      {
+        id: 16,
+        title: "The State of Deepfakes",
+        url: "https://regmedia.co.uk/2019/10/08/deepfake_report.pdf",
+        sourceType: "Report",
+        accessedDate: "2024-03-10",
+        notes: "Deeptrace's comprehensive analysis of deep fake proliferation"
+      }
+    ]
+  },
+  {
+    id: 9,
+    slug: "natural-language-processing",
+    title: "Natural Language Processing",
+    yearRange: "2010–2020",
+    category: "Language AI",
+    introText: "Natural Language Processing (NLP) advanced dramatically between 2010 and 2020, driven by deep learning breakthroughs. The introduction of word embeddings (Word2Vec, 2013), attention mechanisms, and the Transformer architecture (2017) revolutionised how machines process language. These advances enabled machine translation that approached human quality, sentiment analysis at scale, and question-answering systems that could understand context and nuance.",
+    shortSummary: "NLP transformed how computers understand, interpret, and generate human language, enabling machine translation, sentiment analysis, and the precursors to modern AI assistants.",
+    howItWorks: "Modern NLP converts words into numerical vectors (embeddings) that capture semantic relationships — 'king' minus 'man' plus 'woman' approximately equals 'queen.' The Transformer architecture introduced self-attention, allowing models to weigh the importance of different words in context. Instead of processing text sequentially, Transformers examine all words simultaneously, learning which words relate to each other regardless of distance in the text. This parallel processing enabled training on much larger datasets.",
+    simpleExample: "Imagine reading a sentence and highlighting which words help you understand each other word. In 'The cat sat on the mat because it was tired,' you'd connect 'it' to 'cat' (not 'mat'). A Transformer does this automatically for every word pair, building a web of relationships.",
+    effectiveUse: "Machine translation, sentiment analysis, named entity recognition, text summarisation, question answering, chatbots, search engine improvement, and content recommendation systems.",
+    realWorldExamples: "Google Translate's dramatic quality improvement (2016 onwards using neural machine translation). Virtual assistants (Siri, Alexa, Google Assistant). Automated email replies (Gmail's Smart Reply). Sentiment analysis tools used by businesses to monitor customer feedback.",
+    advantages: "Broke the language barrier in computing — machines could finally work with human language at useful quality. Enabled automation of previously labour-intensive text processing tasks. Scaled to process billions of documents. Cross-lingual capabilities improved international communication.",
+    limitations: "Models struggled with sarcasm, irony, and cultural context. Required enormous training datasets that reflected existing biases. Smaller and endangered languages were underserved. Processing long documents remained challenging until very recent advances.",
+    misuse: "Automated content generation for spam and disinformation. Mass surveillance through text analysis. Manipulation through sentiment-aware targeted messaging. Automated censorship systems.",
+    ethics: "NLP systems trained on internet text inevitably absorb societal biases — gender, racial, cultural. These biases get amplified when systems operate at scale. The digital divide means NLP advances primarily benefit major languages, potentially marginalising linguistic diversity.",
+    waContext: "WA researchers have applied NLP to mining industry document analysis, environmental impact assessments, and Indigenous language preservation projects. The University of Western Australia has contributed to NLP research in specialised domains relevant to WA's key industries.",
+    media: [
+      {
+        id: 17,
+        type: "image",
+        title: "Language Processing Pipeline",
+        url: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=600",
+        caption: "The complex pipeline of processing natural language"
+      },
+      {
+        id: 18,
+        type: "image",
+        title: "Transformer Architecture",
+        url: "https://images.unsplash.com/photo-1526374965328-7f61d4dc18c5?w=600",
+        caption: "The Transformer architecture revolutionised NLP"
+      }
+    ],
+    references: [
+      {
+        id: 17,
+        title: "Attention Is All You Need",
+        url: "https://arxiv.org/abs/1706.03762",
+        sourceType: "Research Paper",
+        accessedDate: "2024-03-15",
+        notes: "The foundational Transformer paper by Vaswani et al."
+      },
+      {
+        id: 18,
+        title: "Efficient Estimation of Word Representations in Vector Space",
+        url: "https://arxiv.org/abs/1301.3781",
+        sourceType: "Research Paper",
+        accessedDate: "2024-03-15",
+        notes: "Mikolov et al.'s Word2Vec paper"
+      }
+    ]
+  },
+  {
+    id: 10,
+    slug: "large-language-models",
+    title: "Large Language Models",
+    yearRange: "2024",
+    category: "Frontier AI",
+    introText: "Large Language Models (LLMs) are the culmination of decades of AI research, scaling Transformer architectures to hundreds of billions of parameters trained on vast text corpora. Beginning with GPT-3 (2020) and rapidly advancing through GPT-4, Claude, Gemini, and LLaMA, these models demonstrate emergent capabilities that surprise even their creators — from writing code and poetry to passing professional exams and engaging in nuanced reasoning.",
+    shortSummary: "Large language models like GPT-4, Claude, and Gemini represent the current frontier of AI — systems that can generate text, reason, code, and converse with unprecedented fluency and capability.",
+    howItWorks: "LLMs are Transformer neural networks trained on trillions of words from the internet, books, and other text sources. During training, the model learns to predict the next word in a sequence, developing internal representations of grammar, facts, reasoning patterns, and even some form of world knowledge. At inference time, the model generates text word by word, with each word choice influenced by all previous context. Techniques like Reinforcement Learning from Human Feedback (RLHF) further refine the model's outputs to be helpful, honest, and harmless.",
+    simpleExample: "Imagine someone who has read every book, article, and website ever written, and has an extraordinary memory for patterns and relationships. When you ask them a question, they generate an answer by predicting, word by word, what the most helpful and accurate response would look like based on everything they've read.",
+    effectiveUse: "Writing assistance, code generation, analysis and summarisation, education and tutoring, creative brainstorming, customer service, research assistance, language translation, and as reasoning components in larger AI systems.",
+    realWorldExamples: "ChatGPT reached 100 million users within two months of launch. GitHub Copilot assists millions of developers. Claude helps with research and analysis. Google's Gemini integrates AI into search. LLMs now power applications across every industry from healthcare to law to education.",
+    advantages: "Unprecedented versatility — one model handles thousands of tasks. Natural language interface makes AI accessible to non-technical users. Can reason, plan, and generate creative content. Rapidly improving capabilities with each generation. Democratising access to sophisticated AI assistance.",
+    limitations: "Hallucinations — confidently generating false information. Enormous computational and energy costs. Training data cutoff means limited current knowledge. Difficulty with precise calculation and formal logic. Potential for generating harmful content despite safety measures.",
+    misuse: "Mass generation of disinformation. Automated social engineering and phishing. Academic dishonesty. Creation of malicious code. Overwhelming human content creators and journalists. Impersonation and fraud at unprecedented scale.",
+    ethics: "LLMs raise profound questions about intellectual property (trained on copyrighted works), employment displacement, educational integrity, information reliability, and the concentration of AI power in a few large companies. The energy consumption of training and running these models also raises environmental concerns.",
+    waContext: "WA's technology sector is rapidly adopting LLMs across mining, agriculture, healthcare, and education. Perth-based startups are building LLM-powered tools for the resources industry. WA universities are integrating AI literacy into curricula and researching LLM applications for remote and regional service delivery — a key concern for geographically vast Western Australia.",
+    media: [
+      {
+        id: 19,
+        type: "image",
+        title: "Modern AI Interface",
+        url: "https://images.unsplash.com/photo-1677442136019-21780ecad995?w=600",
+        caption: "The conversational interfaces that made LLMs accessible to everyone"
+      },
+      {
+        id: 20,
+        type: "image",
+        title: "AI Computing Infrastructure",
+        url: "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=600",
+        caption: "The massive computing infrastructure required to train LLMs"
+      }
+    ],
+    references: [
+      {
+        id: 19,
+        title: "GPT-4 Technical Report",
+        url: "https://arxiv.org/abs/2303.08774",
+        sourceType: "Research Paper",
+        accessedDate: "2024-03-20",
+        notes: "OpenAI's technical report on GPT-4"
+      },
+      {
+        id: 20,
+        title: "On the Dangers of Stochastic Parrots",
+        url: "https://dl.acm.org/doi/10.1145/3442188.3445922",
+        sourceType: "Research Paper",
+        accessedDate: "2024-03-20",
+        notes: "Bender et al.'s influential critique of LLMs"
+      }
+    ]
+  }
+];
+function getTopicBySlug(slug) {
+  return topics.find(topic => topic.slug === slug);
+}
+
+function getAdjacentTopics(id) {
+  const index = topics.findIndex(topic => topic.id === id);
+  return {
+    prev: index > 0 ? topics[index - 1] : null,
+    next: index < topics.length - 1 ? topics[index + 1] : null
+  };
+}

--- a/templates/explore_WA.html
+++ b/templates/explore_WA.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Explore WA - AI Museum</title>
+  <link rel="stylesheet" href="../static/css/explore-wa.css" />
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header glass-panel">
+      <div class="container nav-bar">
+        <a href="home.html" class="logo-link">
+          <div class="logo-circle">🧭</div>
+          <div class="logo-text">
+            <span class="logo-title brass-text">AI Museum</span>
+            <span class="logo-subtitle">Western Australia</span>
+          </div>
+        </a>
+
+        <nav class="desktop-nav" id="desktopNav"></nav>
+        <button class="mobile-toggle" id="mobileToggle" aria-label="Open menu">☰</button>
+      </div>
+
+      <nav class="mobile-nav" id="mobileNav"></nav>
+    </header>
+
+    <main class="main-content">
+      <div class="container page-section">
+        <section class="hero-block fade-in">
+          <span class="exhibit-label">Regional Heritage</span>
+          <h1 class="page-title brass-text">Explore WA: Our Place in AI History</h1>
+          <p class="hero-text">
+            Western Australia's story within global AI development is unique — shaped by its vast geography,
+            dominant industries, world-class universities, and growing technology sector.
+          </p>
+        </section>
+
+        <section class="museum-card why-wa">
+          <div class="section-icon">🗺️</div>
+          <span class="exhibit-label">Why Western Australia Matters</span>
+          <p>
+            Western Australia occupies a third of the Australian continent, with a population concentrated
+            in Perth and a vast regional hinterland dependent on mining, agriculture, and environmental
+            management. These conditions have driven unique applications of AI — from autonomous mining
+            vehicles in the Pilbara to precision agriculture in the Wheatbelt, from marine conservation
+            AI on the Ningaloo coast to remote healthcare delivery across distances greater than most
+            European countries.
+          </p>
+          <p>
+            WA's universities — UWA, Curtin, Murdoch, and ECU — have contributed to AI research across
+            every paradigm represented in this museum. The state's technology sector, centred in Perth,
+            is rapidly growing and positioning itself as a hub for AI innovation in the Indo-Pacific region.
+          </p>
+        </section>
+
+        <section class="institution-grid">
+          <article class="museum-card">
+            <div class="section-icon">🎓</div>
+            <h3>Universities</h3>
+            <p>
+              UWA, Curtin, ECU, and Murdoch have strong computer science and AI research programs,
+              with alumni contributing to global AI companies and research institutions.
+            </p>
+          </article>
+
+          <article class="museum-card">
+            <div class="section-icon">🏢</div>
+            <h3>Tech Sector</h3>
+            <p>
+              Perth's tech sector is growing rapidly, with startups and established companies applying
+              AI to mining, healthcare, agriculture, and environmental management.
+            </p>
+          </article>
+
+          <article class="museum-card">
+            <div class="section-icon">⛏️</div>
+            <h3>Resources Industry</h3>
+            <p>
+              WA's mining giants (Rio Tinto, BHP, Fortescue) operate some of the world's most advanced
+              autonomous and AI-driven operations, pioneered right here.
+            </p>
+          </article>
+        </section>
+
+        <section class="parchment-panel uwa-panel">
+          <span class="exhibit-label">UWA & WA Computing Heritage</span>
+          <p>
+            The University of Western Australia established one of Australia's earliest computer science
+            departments. From early adoption of mainframe computing in the 1960s to pioneering AI research
+            in the 1990s and 2000s, UWA has been central to WA's computing story. Today, UWA's research
+            groups in machine learning, computer vision, and natural language processing contribute to
+            both academic knowledge and industry applications.
+          </p>
+          <p class="small-muted">
+            Future additions to this section will include interviews with WA computing pioneers,
+            archival photographs, and oral histories documenting the growth of computing and AI in the state.
+          </p>
+        </section>
+
+        <section class="timeline-section">
+          <span class="exhibit-label timeline-label">WA Connections Across the Timeline</span>
+          <div id="topicsList" class="topics-list"></div>
+        </section>
+
+        <section class="museum-card coming-soon">
+          <div class="section-icon large">🗺️</div>
+          <span class="exhibit-label">Coming Soon</span>
+          <h3>WA-Specific Interviews & Research</h3>
+          <p>
+            Future updates will include recorded interviews with WA computing pioneers,
+            case studies from WA industry AI deployments, and contributions from regional
+            researchers and practitioners.
+          </p>
+        </section>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p class="exhibit-label">A.I. Software Technology in Western Australia</p>
+        <p class="footer-text">A Virtual Museum Experience · Final Semester Project · 2024</p>
+      </div>
+    </footer>
+  </div>
+  <script src="../static/js/topic_data.js"></script>
+  <script src="../static/js/explore-wa.js"></script>
+</body>
+</html>

--- a/templates/topic_detail.html
+++ b/templates/topic_detail.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Topic Detail - AI Museum</title>
+  <link rel="stylesheet" href="../static/css/topic-detail.css" />
+</head>
+<body>
+  <div class="site-wrapper">
+    <header class="site-header glass-panel">
+      <div class="container nav-bar">
+        <a href="home.html" class="logo-link">
+          <div class="logo-circle">🧭</div>
+          <div class="logo-text">
+            <span class="logo-title brass-text">AI Museum</span>
+            <span class="logo-subtitle">Western Australia</span>
+          </div>
+        </a>
+
+        <nav class="desktop-nav" id="desktopNav"></nav>
+        <button class="mobile-toggle" id="mobileToggle" aria-label="Open menu">☰</button>
+      </div>
+
+      <nav class="mobile-nav" id="mobileNav"></nav>
+    </header>
+
+    <main class="main-content">
+      <div class="container page-section">
+        <div class="breadcrumb" id="breadcrumb"></div>
+        <section id="topicHeader"></section>
+
+        <div class="content-grid">
+          <div class="main-column">
+            <div id="introCard"></div>
+            <div id="summaryCard"></div>
+            <div id="sectionsContainer"></div>
+          </div>
+
+          <aside class="sidebar-column">
+            <div id="mediaCard"></div>
+            <div id="referencesCard"></div>
+            <div id="relatedCard"></div>
+          </aside>
+        </div>
+
+        <div class="archival-divider"></div>
+        <div class="bottom-nav" id="bottomNav"></div>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p class="exhibit-label">A.I. Software Technology in Western Australia</p>
+        <p class="footer-text">A Virtual Museum Experience · Final Semester Project · 2024</p>
+      </div>
+    </footer>
+  </div>
+  <script src="../static/js/topic_data.js"></script>
+  <script src="../static/js/topic-detail.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Summary:
- Updated the navigation bar to match the pages currently covered by our group
- Built the initial Explore WA page
- Implemented navigation from Explore WA to the 10 AI Paradigm Shifts topic detail pages
- Added topic detail page support using shared topic data

Details:
- Removed unused navigation items and kept only the relevant project pages
- Created the Explore WA landing interface
- Added clickable topic cards for all 10 AI Paradigm Shifts
- Enabled topic detail page rendering based on slug parameters
- Reduced duplicated code by reusing shared topic data across pages